### PR TITLE
[GPU][Codegen] Distribute to single subgroup for large parallel dimension in reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -385,16 +385,19 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
   static const ChipDetails mi300aChip = {228, "mi300a"};
   static const ChipDetails mi308xChip = {80, "mi308x"};
   static const ChipDetails mi325xChip = {304, "mi325x"};
+  static const ChipDetails gfx942GenericChip = {304, std::nullopt};
 
   // "AMD Instinct MI200 Series Accelerator Product Offerings" in Page 14 of
   // https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna2-white-paper.pdf
   static const ChipDetails mi250xChip = {220, "mi250x"};
   static const ChipDetails mi250Chip = {208, "mi250"};
   static const ChipDetails mi210Chip = {104, "mi210"};
+  static const ChipDetails gfx90aGenericChip = {220, std::nullopt};
 
   // "AMD CDNA Architecture Compute Units" in Page 5 of
   // https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna-white-paper.pdf
   static const ChipDetails mi100Chip = {120, "mi100"};
+  static const ChipDetails gfx908GenericChip = {120, std::nullopt};
 
   // --- RDNA --- //
 
@@ -411,6 +414,7 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
   static const ChipDetails rx9070xtChip = {64 / 2, "rx9070xt"};
   static const ChipDetails rx9070Chip = {56 / 2, "rx9070"};
   static const ChipDetails rx9060xtChip = {32 / 2, "rx9060xt"};
+  static const ChipDetails rdna4GenericChip = {64 / 2, std::nullopt};
 
   // AMD RDNA3.
   static const ChipDetails rx7900xtxChip = {96 / 2, "rx7900xtx"};
@@ -421,22 +425,23 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
   static const ChipDetails w7900Chip = {96 / 2, "w7900"};
   static const ChipDetails w7800Chip = {70 / 2, "w7800"};
   static const ChipDetails w7700Chip = {48 / 2, "w7700"};
+  static const ChipDetails rdna3GenericChip = {96 / 2, std::nullopt};
 
   // See https://llvm.org/docs/AMDGPUUsage.html#processors for gfxN to
   // cdnaN/rdnaN mapping.
   return llvm::StringSwitch<std::optional<TargetDetails>>(target.lower())
-      .Cases("cdna4", "gfx950", TargetDetails{cdna4Wgp, nullptr})
+      .Cases("cdna4", "gfx950", TargetDetails{cdna4Wgp, &gfx942GenericChip})
       .Case("mi325x", TargetDetails{cdna3Wgp, &mi325xChip})
       .Case("mi300x", TargetDetails{cdna3Wgp, &mi300xChip})
       .Case("mi300a", TargetDetails{cdna3Wgp, &mi300aChip})
       .Case("mi308x", TargetDetails{cdna3Wgp, &mi308xChip})
-      .Cases("cdna3", "gfx942", TargetDetails{cdna3Wgp, nullptr})
+      .Cases("cdna3", "gfx942", TargetDetails{cdna3Wgp, &gfx942GenericChip})
       .Case("mi250x", TargetDetails{cdna2Wgp, &mi250xChip})
       .Case("mi250", TargetDetails{cdna2Wgp, &mi250Chip})
       .Case("mi210", TargetDetails{cdna2Wgp, &mi210Chip})
-      .Cases("cdna2", "gfx90a", TargetDetails{cdna2Wgp, nullptr})
+      .Cases("cdna2", "gfx90a", TargetDetails{cdna2Wgp, &gfx90aGenericChip})
       .Case("mi100", TargetDetails{cdna1Wgp, &mi100Chip})
-      .Cases("cdna1", "gfx908", TargetDetails{cdna1Wgp, nullptr})
+      .Cases("cdna1", "gfx908", TargetDetails{cdna1Wgp, &gfx908GenericChip})
       // https://www.techpowerup.com/gpu-specs/radeon-rx-9070-xt.c4229
       .Case("rx9070xt", TargetDetails{rdna4Wgp, &rx9070xtChip})
       // https://www.techpowerup.com/gpu-specs/radeon-rx-9070.c4250
@@ -461,9 +466,9 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
       .Case("w7800", TargetDetails{rdna3Wgp, &w7800Chip})
       // https://www.techpowerup.com/gpu-specs/radeon-pro-w7700.c4184
       .Case("w7700", TargetDetails{rdna3Wgp, &w7700Chip})
-      .Cases("rdna4", "gfx1200", "gfx1201", TargetDetails{rdna4Wgp, nullptr})
+      .Cases("rdna4", "gfx1200", "gfx1201", TargetDetails{rdna4Wgp, &rdna4GenericChip})
       .Cases("rdna3", "gfx1100", "gfx1101", "gfx1102", "gfx1103", "gfx1150",
-             "gfx1151", TargetDetails{rdna3Wgp, nullptr})
+             "gfx1151", TargetDetails{rdna3Wgp, &rdna3GenericChip})
       .Cases("rdna2", "gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034",
              "gfx1035", "gfx1036", TargetDetails{rdna2Wgp, nullptr})
       .Cases("rdna1", "gfx1010", "gfx1011", "gfx1012", "gfx1013",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -859,19 +859,6 @@ setReductionVectorDistributionConfig(IREE::GPU::TargetAttr target,
       threadLoads /= 2;
     }
   }
-  // Deduce the workgroup size we should use for reduction. Currently a
-  // workgroup processes all elements in reduction dimensions. Need to make sure
-  // the workgroup size we use can divide the total reduction size, and it's
-  // also within hardware limitations.
-  ArrayRef<int32_t> maxWgSizes = wgp.getMaxWorkgroupSizes();
-  const int64_t maxWorkgroupSize = *std::max_element(maxWgSizes.begin(), maxWgSizes.end());
-  int64_t workgroupSize = reductionSize / threadLoads;
-  if (workgroupSize > maxWorkgroupSize) {
-    workgroupSize = llvm::APIntOps::GreatestCommonDivisor(
-                        {64, static_cast<uint64_t>(workgroupSize)},
-                        {64, static_cast<uint64_t>(maxWorkgroupSize)})
-                        .getZExtValue();
-  }
 
   std::optional<int64_t> parallelSize = 1;
   for (int64_t dim : parallelDims) {
@@ -882,10 +869,40 @@ setReductionVectorDistributionConfig(IREE::GPU::TargetAttr target,
     *parallelSize *= bounds[dim];
   }
 
+  // Deduce the workgroup size we should use for reduction. Currently a
+  // workgroup processes all elements in reduction dimensions. Need to make sure
+  // the workgroup size we use can divide the total reduction size, and it's
+  // also within hardware limitations.
+  ArrayRef<int32_t> maxWgSizes = wgp.getMaxWorkgroupSizes();
+  int64_t maxWorkgroupSize = *std::max_element(maxWgSizes.begin(), maxWgSizes.end());
   IREE::GPU::TargetChipAttr chip = target.getChip();
   int numComputeUnits = chip ? chip.getWgpCount() : 256;
+
+  // If there is enough work to saturate all CUs * 2, use single subgroup per workgroup
   if (parallelSize && *parallelSize > numComputeUnits * 2)
-    workgroupSize = target.getPreferredSubgroupSize();
+    maxWorkgroupSize = target.getPreferredSubgroupSize();
+
+  int64_t workgroupSize = reductionSize / threadLoads;
+  if (workgroupSize > maxWorkgroupSize) {
+    workgroupSize = llvm::APIntOps::GreatestCommonDivisor(
+                        {64, static_cast<uint64_t>(workgroupSize)},
+                        {64, static_cast<uint64_t>(maxWorkgroupSize)})
+                        .getZExtValue();
+  }
+
+  // Total parallel size that can fill the GPU with enough workgorups.
+  // TODO: query from the target device; roughly 2x hardware compute unit.
+  const int parallelThreshold = 256;
+  // How many 128-bit vectors each thread should at least read.
+  const int targetVectorCount = 8;
+  while (parallelSize && *parallelSize > parallelThreshold &&
+         (workgroupSize / 2) % subgroupSize == 0 &&
+         reductionSize / (workgroupSize * threadLoads) < targetVectorCount) {
+    // Use less subgroups per workgroup..
+    workgroupSize /= 2;
+    // in order to host more workgroups per hardware compute unit.
+    *parallelSize /= 2;
+  }
 
   // TODO(pashu123): Currently, the threadLoads is done on the basis of
   // the root operation and ignores other operation within a dispatch.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -499,7 +499,7 @@ getVectorDistributeReductionConfig(
     const int64_t maxParallelFactor = workgroupSize / 4;
     for (int64_t parallelFactor = 2; (parallelFactor < maxParallelFactor) &&
                                      (parallelBound % parallelFactor == 0) &&
-                                     (parallelBound > parallelFactor);
+                                     (parallelBound >= parallelFactor);
          parallelFactor *= 2) {
       numParallelReductions = parallelFactor;
     }
@@ -862,7 +862,7 @@ setReductionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // workgroup processes all elements in reduction dimensions. Need to make sure
   // the workgroup size we use can divide the total reduction size, and it's
   // also within hardware limitations.
-  const int64_t maxWorkgroupSize = 1024;
+  const int64_t maxWorkgroupSize = 64;
   int64_t workgroupSize = reductionSize / threadLoads;
   if (workgroupSize > maxWorkgroupSize) {
     workgroupSize = llvm::APIntOps::GreatestCommonDivisor(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/LLVMGPU/KernelConfig.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <numeric>
 #include <optional>
@@ -499,7 +500,7 @@ getVectorDistributeReductionConfig(
     const int64_t maxParallelFactor = workgroupSize / 4;
     for (int64_t parallelFactor = 2; (parallelFactor < maxParallelFactor) &&
                                      (parallelBound % parallelFactor == 0) &&
-                                     (parallelBound >= parallelFactor);
+                                     (parallelBound > parallelFactor);
          parallelFactor *= 2) {
       numParallelReductions = parallelFactor;
     }
@@ -862,7 +863,8 @@ setReductionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // workgroup processes all elements in reduction dimensions. Need to make sure
   // the workgroup size we use can divide the total reduction size, and it's
   // also within hardware limitations.
-  const int64_t maxWorkgroupSize = 64;
+  ArrayRef<int32_t> maxWgSizes = wgp.getMaxWorkgroupSizes();
+  const int64_t maxWorkgroupSize = *std::max_element(maxWgSizes.begin(), maxWgSizes.end());
   int64_t workgroupSize = reductionSize / threadLoads;
   if (workgroupSize > maxWorkgroupSize) {
     workgroupSize = llvm::APIntOps::GreatestCommonDivisor(
@@ -880,19 +882,10 @@ setReductionVectorDistributionConfig(IREE::GPU::TargetAttr target,
     *parallelSize *= bounds[dim];
   }
 
-  // Total parallel size that can fill the GPU with enough workgorups.
-  // TODO: query from the target device; roughly 2x hardware compute unit.
-  const int parallelThreshold = 256;
-  // How many 128-bit vectors each thread should at least read.
-  const int targetVectorCount = 8;
-  while (parallelSize && *parallelSize > parallelThreshold &&
-         (workgroupSize / 2) % subgroupSize == 0 &&
-         reductionSize / (workgroupSize * threadLoads) < targetVectorCount) {
-    // Use less subgroups per workgroup..
-    workgroupSize /= 2;
-    // in order to host more workgroups per hardware compute unit.
-    *parallelSize /= 2;
-  }
+  IREE::GPU::TargetChipAttr chip = target.getChip();
+  int numComputeUnits = chip ? chip.getWgpCount() : 256;
+  if (parallelSize && *parallelSize > numComputeUnits * 2)
+    workgroupSize = target.getPreferredSubgroupSize();
 
   // TODO(pashu123): Currently, the threadLoads is done on the basis of
   // the root operation and ignores other operation within a dispatch.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -439,4 +439,4 @@ func.func @batch_matvec_f16_f32() {
 //  CHECK-SAME:                 partial_reduction = [0, 0, 512],
 //  CHECK-SAME:                 subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
 //  CHECK-SAME:                 thread = [0, 0, 8],
-//  CHECK-SAME:                 workgroup = [4, 1, 0]
+//  CHECK-SAME:                 workgroup = [2, 1, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -88,8 +88,8 @@ func.func @reduction_with_no_consumer() {
 // CHECK-LABEL: func.func @reduction_with_no_consumer
 // CHECK:           lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:      lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]
-// CHECK-SAME:      partial_reduction = [0, 0, 1, 512]
-// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]
+// CHECK-SAME:      partial_reduction = [0, 0, 1, 4096]
+// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 8], [0, 1, 2, 3]
 // CHECK-SAME:      thread = [0, 0, 1, 8],
 // CHECK-SAME:      workgroup = [1, 1, 0, 0]
 
@@ -154,8 +154,8 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:    outs({{.*}}: tensor<2x32xf32>)
 // CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 // CHECK-SAME:               lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]],
-// CHECK-SAME:               partial_reduction = [0, 0, 1, 512],
-// CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]],
+// CHECK-SAME:               partial_reduction = [0, 0, 1, 8192],
+// CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]],
 // CHECK-SAME:               thread = [0, 0, 1, 8],
 // CHECK-SAME:               workgroup = [1, 1, 0, 0]
 // CHECK:       %{{.*}} = linalg.generic {indexing_maps = [#map, #map1, #map1],
@@ -164,8 +164,8 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:    outs(%{{.*}} : tensor<2x32xf32>)
 // CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 // CHECK-SAME:              lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]],
-// CHECK-SAME:              partial_reduction = [0, 0, 1, 512],
-// CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]],
+// CHECK-SAME:              partial_reduction = [0, 0, 1, 8192],
+// CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]],
 // CHECK-SAME:              thread = [0, 0, 1, 8],
 // CHECK:       %{{.*}} = linalg.generic {indexing_maps = [#map, #map1, #map1, #map],
 // CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
@@ -173,8 +173,8 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:    outs(%{{.*}} : tensor<2x32x10x16384xf32>)
 // CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 // CHECK-SAME:              lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]]
-// CHECK-SAME:              reduction = [0, 0, 1, 512],
-// CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]],
+// CHECK-SAME:              reduction = [0, 0, 1, 8192],
+// CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]],
 // CHECK-SAME:              thread = [0, 0, 0, 8],
 
 // -----
@@ -241,21 +241,21 @@ func.func @test_multiple_stores(%arg0: !iree_tensor_ext.dispatch.tensor<readonly
   iree_tensor_ext.dispatch.tensor.store %5, %arg4, offsets = [0, 0], sizes = [4, 4096], strides = [1, 1] : tensor<4x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x4096xf32>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 64
 //       CHECK: func.func @test_multiple_stores
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 64], [0, 1]],
-//  CHECK-SAME:               reduction = [0, 256],
-//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1], [0, 1]],
+//  CHECK-SAME:               reduction = [0, 4096],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 16], [0, 1]],
 //  CHECK-SAME:               thread = [0, 4],
 //  CHECK-SAME:               workgroup = [1, 0]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 64], [0, 1]],
-//  CHECK-SAME:               partial_reduction = [0, 256],
-//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1], [0, 1]],
+//  CHECK-SAME:               partial_reduction = [0, 4096],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 16], [0, 1]],
 //  CHECK-SAME:               thread = [0, 4],
 //  CHECK-SAME:               workgroup = [1, 0]
 
@@ -376,7 +376,7 @@ func.func @test_store_to_buffer(%arg0: index, %arg1: index) {
   iree_codegen.store_to_buffer %12, %expand_shape : tensor<?x4xf32> into memref<?x4xf32, #hal.descriptor_type<storage_buffer>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [512, 1, 1] subgroup_size = 64
 // CHECK-LABEL: @test_store_to_buffer
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -384,8 +384,8 @@ func.func @test_store_to_buffer(%arg0: index, %arg1: index) {
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
-//  CHECK-SAME:               partial_reduction = [0, 0, 512],
-//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
+//  CHECK-SAME:               partial_reduction = [0, 0, 4096],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 8], [0, 1, 2]],
 //  CHECK-SAME:               thread = [0, 0, 8],
 //  CHECK-SAME:               workgroup = [1, 1, 0]
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -88,8 +88,8 @@ func.func @reduction_with_no_consumer() {
 // CHECK-LABEL: func.func @reduction_with_no_consumer
 // CHECK:           lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:      lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]
-// CHECK-SAME:      partial_reduction = [0, 0, 1, 4096]
-// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 8], [0, 1, 2, 3]
+// CHECK-SAME:      partial_reduction = [0, 0, 1, 512]
+// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]
 // CHECK-SAME:      thread = [0, 0, 1, 8],
 // CHECK-SAME:      workgroup = [1, 1, 0, 0]
 
@@ -154,8 +154,8 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:    outs({{.*}}: tensor<2x32xf32>)
 // CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 // CHECK-SAME:               lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]],
-// CHECK-SAME:               partial_reduction = [0, 0, 1, 8192],
-// CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]],
+// CHECK-SAME:               partial_reduction = [0, 0, 1, 512],
+// CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]],
 // CHECK-SAME:               thread = [0, 0, 1, 8],
 // CHECK-SAME:               workgroup = [1, 1, 0, 0]
 // CHECK:       %{{.*}} = linalg.generic {indexing_maps = [#map, #map1, #map1],
@@ -164,8 +164,8 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:    outs(%{{.*}} : tensor<2x32xf32>)
 // CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 // CHECK-SAME:              lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]],
-// CHECK-SAME:              partial_reduction = [0, 0, 1, 8192],
-// CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]],
+// CHECK-SAME:              partial_reduction = [0, 0, 1, 512],
+// CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]],
 // CHECK-SAME:              thread = [0, 0, 1, 8],
 // CHECK:       %{{.*}} = linalg.generic {indexing_maps = [#map, #map1, #map1, #map],
 // CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
@@ -173,8 +173,8 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:    outs(%{{.*}} : tensor<2x32x10x16384xf32>)
 // CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 // CHECK-SAME:              lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]]
-// CHECK-SAME:              reduction = [0, 0, 1, 8192],
-// CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]],
+// CHECK-SAME:              reduction = [0, 0, 1, 512],
+// CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]],
 // CHECK-SAME:              thread = [0, 0, 0, 8],
 
 // -----
@@ -241,21 +241,21 @@ func.func @test_multiple_stores(%arg0: !iree_tensor_ext.dispatch.tensor<readonly
   iree_tensor_ext.dispatch.tensor.store %5, %arg4, offsets = [0, 0], sizes = [4, 4096], strides = [1, 1] : tensor<4x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x4096xf32>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
 //       CHECK: func.func @test_multiple_stores
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 64], [0, 1]],
-//  CHECK-SAME:               reduction = [0, 4096],
-//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 16], [0, 1]],
+//  CHECK-SAME:               reduction = [0, 256],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1], [0, 1]],
 //  CHECK-SAME:               thread = [0, 4],
 //  CHECK-SAME:               workgroup = [1, 0]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 64], [0, 1]],
-//  CHECK-SAME:               partial_reduction = [0, 4096],
-//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 16], [0, 1]],
+//  CHECK-SAME:               partial_reduction = [0, 256],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1], [0, 1]],
 //  CHECK-SAME:               thread = [0, 4],
 //  CHECK-SAME:               workgroup = [1, 0]
 
@@ -376,7 +376,7 @@ func.func @test_store_to_buffer(%arg0: index, %arg1: index) {
   iree_codegen.store_to_buffer %12, %expand_shape : tensor<?x4xf32> into memref<?x4xf32, #hal.descriptor_type<storage_buffer>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [512, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: @test_store_to_buffer
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -384,8 +384,8 @@ func.func @test_store_to_buffer(%arg0: index, %arg1: index) {
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
-//  CHECK-SAME:               partial_reduction = [0, 0, 4096],
-//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 8], [0, 1, 2]],
+//  CHECK-SAME:               partial_reduction = [0, 0, 512],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
 //  CHECK-SAME:               thread = [0, 0, 8],
 //  CHECK-SAME:               workgroup = [1, 1, 0]
 
@@ -431,12 +431,12 @@ func.func @batch_matvec_f16_f32() {
   return
 }
 
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: @batch_matvec_f16_f32
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs = {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:                 lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
-//  CHECK-SAME:                 partial_reduction = [0, 0, 2048],
-//  CHECK-SAME:                 subgroup_basis = {{\[}}[1, 1, 4], [0, 1, 2]],
+//  CHECK-SAME:                 partial_reduction = [0, 0, 512],
+//  CHECK-SAME:                 subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
 //  CHECK-SAME:                 thread = [0, 0, 8],
-//  CHECK-SAME:                 workgroup = [2, 1, 0]
+//  CHECK-SAME:                 workgroup = [4, 1, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -202,16 +202,16 @@ func.func @vmt2() attributes {hal.executable.target = #executable_target_rocm_hs
   return
 }
 
-//   CDNA3-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 32
+//   CDNA3-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
 // CDNA3-LABEL: func.func @vmt2()
 //  CDNA3-SAME:     translation_info = #[[$TRANSLATION]]
 //       CDNA3:   linalg.generic
 //  CDNA3-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CDNA3-SAME:               lane_basis = {{\[}}[1, 1, 32], [0, 1, 2]],
-//  CDNA3-SAME:               partial_reduction = [0, 0, 512],
-//  CDNA3-SAME:               subgroup_basis = {{\[}}[1, 1, 2], [0, 1, 2]],
+//  CDNA3-SAME:               partial_reduction = [0, 0, 256],
+//  CDNA3-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
 //  CDNA3-SAME:               thread = [0, 0, 8],
-//  CDNA3-SAME:               workgroup = [1, 8, 0]
+//  CDNA3-SAME:               workgroup = [1, 4, 0]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -148,7 +148,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 }
 }
 
-//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 32
+//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
 //         CHECK:  func.func @softmax()
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
 //         CHECK:    scf.for {{.*}} -> (vector<1x1x4xf32>) {
@@ -156,9 +156,6 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //         CHECK:      arith.maxnumf {{.*}} : vector<1x1x4xf32>
 //         CHECK:      scf.yield
 //         CHECK:    vector.multi_reduction <maxnumf>
-//         CHECK:    gpu.subgroup_reduce  maxnumf
-//         CHECK:    vector.transfer_write
-//         CHECK:    gpu.barrier
 //         CHECK:    gpu.subgroup_reduce  maxnumf
 //         CHECK:    vector.broadcast %{{.*}} : f32 to vector<1x1x4xf32>
 //         CHECK:    scf.for {{.*}} -> (vector<1x1x4xf32>) {
@@ -168,10 +165,6 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //         CHECK:      arith.addf
 //         CHECK:      scf.yield
 //         CHECK:    vector.multi_reduction <add>
-//         CHECK:    gpu.subgroup_reduce  add
-//         CHECK:    vector.transfer_write
-//         CHECK:    gpu.barrier
-//         CHECK:    vector.transfer_read
 //         CHECK:    gpu.subgroup_reduce  add
 //         CHECK:    vector.broadcast
 //         CHECK:    scf.for

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
@@ -300,18 +300,18 @@ hal.executable private @matvec_fp16 {
 // Multi-row matvec with wave32.
 // TODO(kuhar): We should reduce the number of `gpu.shuffles` performed.
 
-//          RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 32
+//          RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
 //          RDNA3: func.func @matvec_fp16()
 //     RDNA3-SAME:     translation_info = #[[$TRANSLATION]]
 //      RDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//      RDNA3-DAG:   %[[C512:.+]] = arith.constant 512 : index
+//      RDNA3-DAG:   %[[C256:.+]] = arith.constant 256 : index
 //      RDNA3-DAG:   %[[C4096:.+]] = arith.constant 4096 : index
-//      RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<8x1x1x1x1x8xf16>
-//          RDNA3:   scf.for %{{.+}} = %[[C0]] to %[[C4096]] step %[[C512]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<8x1x1x1x1x8xf16>)
-//          RDNA3:     {{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
-//          RDNA3:     {{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
+//      RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x8xf16>
+//          RDNA3:   scf.for %{{.+}} = %[[C0]] to %[[C4096]] step %[[C256]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<4x1x1x1x1x8xf16>)
+//          RDNA3:     {{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x8xf16>
+//          RDNA3:     {{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x8xf16>
 
-//          RDNA3: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<8x1x1x1x1x8xf16> to vector<8x1x1xf16>
+//          RDNA3: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<4x1x1x1x1x8xf16> to vector<4x1x1xf16>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_softmax_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_softmax_rocm.mlir
@@ -19,21 +19,19 @@ func.func @softmax() {
   return
 }
 
-//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 32
+//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
 //    CHECK-LABEL: func.func @softmax
 //     CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//     CHECK:    gpu.subgroup_reduce  maxnumf {{.*}} cluster(size = 32) : (f32) -> f32
 //     CHECK:    gpu.subgroup_reduce  maxnumf {{.*}} cluster(size = 32) : (f32) -> f32
 //     CHECK:    gpu.subgroup_reduce  add {{.*}} cluster(size = 32) : (f32) -> f32
 
 // On CDNA, we prefer wave64 with subgroup size 64.
 
-//          CDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 64
+//          CDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
 //          CDNA3: func.func @softmax
 //     CDNA3-SAME:      translation_info = #[[$TRANSLATION]]
 //     CDNA3:    gpu.subgroup_reduce  maxnumf {{.*}} cluster(size = 64) : (f32) -> f32
-//     CDNA3:    gpu.subgroup_reduce  maxnumf {{.*}} cluster(size = 16) : (f32) -> f32
-//     CDNA3:    gpu.subgroup_reduce  add {{.*}} cluster(size = 16) : (f32) -> f32
+//     CDNA3:    gpu.subgroup_reduce  add {{.*}} cluster(size = 64) : (f32) -> f32
 
 // -----
 


### PR DESCRIPTION
Prioritize distributing to just a single subgroup along the reduction dimension when the problem size is large enough for us to saturate all CUs. Default to prior behavior when parallel dimensions are small (I use 2 * number of CUs here conservatively which aligned with Prashant's comment, but not sure if this is correct). This avoids needing to write/read to shared memory for a cross-group reduction. More details to come with examples and performance differences.

When only an architecture is specified and not a specific device, default to using the most conservative number of CUs within that generation. 